### PR TITLE
WIP: update trimmed addresses

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/newchain/newaddress.ex
+++ b/apps/block_scout_web/lib/block_scout_web/newchain/newaddress.ex
@@ -43,7 +43,7 @@ defmodule NewChain.Address do
       address
       |> to_string
       |> hexAddress2NewAddress(chainId)
-    "#{String.slice(newAddress, 0..6)}–#{String.slice(newAddress, -5..-1)}"
+    "#{String.slice(newAddress, 0..8)}···#{String.slice(newAddress, -6..-1)}"
   end
 
   def fullNewAddressEasy(address, chainId \\ 1012) when is_integer(chainId) do

--- a/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
@@ -264,7 +264,7 @@ defmodule BlockScoutWeb.AddressView do
 
   def trimmed_hash(%Hash{} = hash) do
     string_hash = to_string(hash)
-    "#{String.slice(string_hash, 0..5)}–#{String.slice(string_hash, -6..-1)}"
+    "#{String.slice(string_hash, 0..5)}···#{String.slice(string_hash, -6..-1)}"
   end
 
   def trimmed_hash(_), do: ""


### PR DESCRIPTION
from Newton Product Guideline
1. trimmed hex and NEW addresses are using ··· as mask and seperators.
2. trimmed NEW address: NEW+`###`+`abc`+`···`+`uvwxyz`